### PR TITLE
hotfix/1.9.3 Fix deprecated imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This file is used to explain in detail changes made to the Table.
 <!-- TOC -->
   [[TOC]]
 
+## V 1.9.3
+Date: Nov 25, 2024
+* [FIX]
+  * Fix sass warnings for 5BIMP due to deprecated code
+
 ## V 1.9.2
 Date: Nov 05, 2024
 * [FIX]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermosillo-i3/table-pkg",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/_base.scss
+++ b/src/_base.scss
@@ -1,4 +1,4 @@
-@import './variables';
+@use './variables' as *;
 
 * {
     box-sizing: border-box;

--- a/src/components/Table/Table.scss
+++ b/src/components/Table/Table.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 //  Colors
 $row_total: #e65a28;
 $header_lv_0: #172c33;
@@ -845,7 +847,7 @@ $font-color-header: #ffffff;
 }
 
 .Table-Row--striped {
-  background-color: lighten($color: $header_lv_4, $amount: 5);
+  background-color: color.adjust($color: $header_lv_4, $lightness: 5%);
 }
 
 .Table-Row-Empty {


### PR DESCRIPTION
Se cambia un https://github.com/import por un @use para eliminar los warnings por utilizar código deprecado
https://app.asana.com/0/1203923044152323/1208810062359714/f