### PR TITLE
hotfix/revert using ellipsis for overflowed texts on text inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # FIVEBIM-TABLE.
 This file is used to explain in detail changes made to the Table.
 
+## V 1.17.9
+Date: Sept 5, 2025
+* [FIX]
+  * Revert from using an ellipsis as overflow, to wrapping the text for non-editable text cells
+
 ## V 1.17.8
 Date: Sep 4, 2025
 * [FIX]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermosillo-i3/table-pkg",
-  "version": "1.17.8",
+  "version": "1.17.9",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/InputField.js
+++ b/src/components/InputField.js
@@ -711,10 +711,13 @@ class InputField extends React.Component {
                 maxWidth: '100%',
                 margin: this.props.allowNewRowSelectionProcess ? '5px 0px 5px 0px' : '0',
                 border: shouldShowBorder ? '2px solid #1f76b7' : '2px solid transparent',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
+                overflow: 'visible',
+                wordWrap: 'break-word',
+                overflowWrap: 'break-word',
+                whiteSpace: 'normal',
                 boxSizing: 'border-box',
+                display: 'flex',
+                alignItems: 'center',
               }}
             >
               <span className={`${compressLongText ? "compress-row" : ""}`}>

--- a/src/components/Table/Table.scss
+++ b/src/components/Table/Table.scss
@@ -1636,7 +1636,7 @@ input.InputField {
       //transition: border-color 0.15s ease-in-out 0s, box-shadow 0.15s ease-in-out 0s;
       overflow: hidden;
       text-overflow: ellipsis;
-      white-space: nowrap;
+      white-space: normal;
       max-width: 100%;
     }
 


### PR DESCRIPTION
## **Descripción de la tarea**
Se revierte el overflow: ellipsis que se había agregado a las celdas no editables y a los InputField de tipo texto en la segunda iteración del feature para el nuevo proceso de selección de rows

https://app.asana.com/1/527644457818985/project/1209109989396262/task/1211199527454582?focus=true

## **Acuerdos**

- Los comments les da resolve la persona que los hace.
- Aprobar un pull request antes de cerrarlo (no puede ser quien lo crea).
- Los PR los cierra la persona que los crea.
- Usar botón de viewed al momento de revisar cada archivo para llevar un orden de la revisión.
- Al cerrar el PR usar squash and merge para evitar tantos commits en la rama principal.
