### PR TITLE
Hotfix: data-testid for cells and toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # FIVEBIM-TABLE.
 This file is used to explain in detail changes made to the Table.
 
+## V 1.18.21
+Date: Mar 31, 2026
+* [NEW]
+  * Add `data-testid` on data cells (`data-cell-{rowIndex}-{colIndex}`) for automated testing
+  * Add `data-testid` on toolbar actions: `table-expand-all-rows-button`, `table-expand-row-button`, `table-collapse-all-rows-button`, `table-collapse-row-button`, `table-download-button`, `table-settings-button`
+  * Pass `rowIndex` into `InputField` from row rendering
+
 ## V 1.18.20
 Date: Mar 30, 2026
 * [TEST]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermosillo-i3/table-pkg",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -442,6 +442,7 @@ const rowFunctionComponent = (props) => {
                         filter_hermosillo_non_working_days={props.filter_hermosillo_non_working_days}
                         allowNewRowSelectionProcess={allowNewRowSelectionProcess}
                         colIndex={colIndex}
+                        rowIndex={rowIndex}
                         hoveredCellIndex={hoveredCellIndex}
                      />
                   </div>
@@ -565,6 +566,7 @@ const rowFunctionComponent = (props) => {
             let cellContent = col.Cell ? col.Cell(row) : null;
             let cellToRender = (col.Cell && cellContent !== null && cellContent !== undefined ? (
                <td
+                  data-testid={`data-cell-${rowIndex}-${colIndex}`}
                   onClick={(e) => onCellClick(col, row, colIndex, rowIndex, e)}
                   onDoubleClick={(e) => onCellDoubleClick(col, row, colIndex, rowIndex, e)}
                   onContextMenu={(e) => onCellContextMenu(col, row, colIndex, rowIndex, e)}
@@ -607,6 +609,7 @@ const rowFunctionComponent = (props) => {
 
             ) : (
                <td
+                  data-testid={`data-cell-${rowIndex}-${colIndex}`}
                   onClick={(e) => onCellClick(col, row, colIndex, rowIndex, e)}
                   onDoubleClick={(e) => onCellDoubleClick(col, row, colIndex, rowIndex, e)}
                   onContextMenu={(e) => onCellContextMenu(col, row, colIndex, rowIndex, e)}

--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -193,7 +193,7 @@ export default class Toolbar extends React.Component {
                return (
                   <Popup
                      trigger={
-                        <Button style={button_style} size={icon_size} icon='angle double down' basic
+                        <Button data-testid="table-expand-all-rows-button" style={button_style} size={icon_size} icon='angle double down' basic
                            onClick={props.expandElements.action} type="button" />
                      }
                      content='Expandir todos los elementos'
@@ -205,7 +205,7 @@ export default class Toolbar extends React.Component {
                   return (
                      <Popup
                         trigger={
-                           <Button style={button_style} size={icon_size} icon='angle down' basic
+                           <Button data-testid="table-expand-row-button" style={button_style} size={icon_size} icon='angle down' basic
                               onClick={props.expandElements.action} type="button" />
                         }
                         content='Expandir elementos seleccionados'
@@ -223,7 +223,7 @@ export default class Toolbar extends React.Component {
                return (
                   <Popup
                      trigger={
-                        <Button style={button_style} size={icon_size} icon='angle double up' basic
+                        <Button data-testid="table-collapse-all-rows-button" style={button_style} size={icon_size} icon='angle double up' basic
                            onClick={props.collapseElements.action} type="button" />
                      }
                      content='Contraer todos los elementos'
@@ -235,7 +235,7 @@ export default class Toolbar extends React.Component {
                   return (
                      <Popup
                         trigger={
-                           <Button style={button_style} size={icon_size} icon='angle up' basic
+                           <Button data-testid="table-collapse-row-button" style={button_style} size={icon_size} icon='angle up' basic
                               onClick={props.collapseElements.action} type="button" />
                         }
                         content='Contraer elementos seleccionados'
@@ -309,6 +309,7 @@ export default class Toolbar extends React.Component {
                         <Popup
                            trigger={
                               <Button
+                                 data-testid="table-download-button"
                                  style={button_style}
                                  size={icon_size}
                                  icon='download'
@@ -324,6 +325,7 @@ export default class Toolbar extends React.Component {
                   {allowToOpenSettings && <Popup
                      trigger={
                         <Button
+                           data-testid="table-settings-button"
                            style={button_style}
                            size={icon_size}
                            icon='setting'


### PR DESCRIPTION
## Summary

Patch release **1.18.21** adds stable selectors for automated testing.

### Changes
- **Row.js**: `data-testid={`data-cell-${rowIndex}-${colIndex}`}` on data `<td>` elements; pass `rowIndex` to `InputField`.
- **Toolbar.js**: `data-testid` on expand/collapse (all vs selected), download, and settings buttons.

### Release
- `package.json` version → `1.18.21`
- `CHANGELOG.md` updated

### Verification
- Build or Storybook smoke check as needed for your pipeline.

Made with [Cursor](https://cursor.com)