### PR TITLE
[Feature] Add action queue for toolbar actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # FIVEBIM-TABLE.
 This file is used to explain in detail changes made to the Table.
 
+## V 1.18.24
+Date: Jul 17, 2026
+* [NEW]
+  * Add `createActionQueue` utility and optional `queueKey` on toolbar actions to serialize rapid clicks
+* [UPDATE]
+  * Toolbar routes actions through the queue when `queueKey` is set; `custom_button` receives `onClick`, `loading`, and `disabled`
+
 ## V 1.18.23
 Date: May 22, 2026
 * [FIX]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Date: Jul 17, 2026
   * Add `createActionQueue` utility and optional `queueKey` on toolbar actions to serialize rapid clicks
 * [UPDATE]
   * Toolbar routes actions through the queue when `queueKey` is set; `custom_button` receives `onClick`, `loading`, and `disabled`
+  * Remove logic to add code between gap in generateCode function
+  * Allow paste into focused input fields in Table Component
 
 ## V 1.18.23
 Date: May 22, 2026

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermosillo-i3/table-pkg",
-  "version": "1.18.23",
+  "version": "1.18.24",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -866,6 +866,12 @@ class Table extends React.Component {
 
    onPaste = (e) => {
       if (this.props.onPasteRows) {
+         // When a cell input is focused, let the browser paste into that field.
+         const isEditingCell = e?.target && (e?.target?.tagName === 'INPUT' || e?.target?.tagName === 'TEXTAREA' || e?.target?.isContentEditable);
+         if (isEditingCell) {
+            return;
+         }
+
          const rows = getClipboardTextFromExcel(e);
          const selected_rows = this.props.selected_rows ? this.props.selected_rows : [];
          const {newRows, errorRows, errorRowIndexes} = fixRowsFromClipboard(rows, this.props.pastedRowsValidator);

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -2015,6 +2015,7 @@ Table.propTypes = {
       subIcon: PropTypes.string,
       subIconPosition: PropTypes.string,
       action: PropTypes.func,
+      queueKey: PropTypes.string,
       position: PropTypes.oneOf(['left', 'right']),
       custom_button: PropTypes.func
    })),

--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -5,6 +5,7 @@ import Select from "react-select";
 import ModalForm from "../ModalForm";
 import { CSVLink } from "react-csv";
 import { convertTreeStructureToFlatArray, filterRowValues } from "../../utils/Utils";
+import createActionQueue from "../../utils/actionQueue";
 import './Toolbar.scss';
 
 
@@ -51,6 +52,7 @@ export default class Toolbar extends React.Component {
 
    constructor(props) {
       super(props);
+      this.actionQueue = createActionQueue();
       this.state = {
          is_create_profile_modal_open: false
       }
@@ -82,6 +84,19 @@ export default class Toolbar extends React.Component {
       const {rows = []} = this.props;
       const filteredRows = rows.map((row) => filterRowValues(row));
       return convertTreeStructureToFlatArray(filteredRows, 'subrows');
+   }
+
+   handleActionClick = (item) => {
+      const {action, queueKey} = item;
+      if (!action) {
+         return undefined;
+      }
+
+      if (queueKey) {
+         return this.actionQueue.enqueue(queueKey, action);
+      }
+
+      return action();
    }
 
    render() {
@@ -154,9 +169,15 @@ export default class Toolbar extends React.Component {
                </div>
             )
          }
+         const onClick = () => this.handleActionClick(item);
+
          if (item.custom_button)
             return React.cloneElement(
-               item.custom_button(),
+               item.custom_button({
+                  onClick,
+                  loading: item.loading,
+                  disabled: item.disabled,
+               }),
                { key: item.name }
             );
          else
@@ -167,7 +188,7 @@ export default class Toolbar extends React.Component {
                   icon={item.icon !== undefined}
                   size={item.icon ? "large" : "small"}
                   active={item.active}
-                  onClick={item.action}
+                  onClick={onClick}
                   loading={item.loading}
                   disabled={item.disabled}
                   type="button"

--- a/src/utils/Utils.js
+++ b/src/utils/Utils.js
@@ -151,9 +151,9 @@ export const chunk = (str, n) => {
 };
 
 /** Generate a new code for a table row from the current codes in the table following these rules
- * It will the next lowest code posible.
+ * It will the next lowest code posible for the last code in the array.
  * Given an array of codes such as ['1','2']. The next lowest posible code will be '3'
- * Given an array of codes such as ['1','3']. The next lowest posible code will be '2'
+ * Given an array of codes such as ['1','3']. The next lowest posible code will be '4'
  * @param {Array} _array The list of codes that are already in the table
  * @param {Boolean} code_length The length of the new code, EJ. if the code is 1 but length = 2 , the code will be 01
  * @return {String} The generated code
@@ -164,25 +164,10 @@ export const generateCode = (_array, code_length = 2) => {
       // Remove any invalid code
       let array = _array.filter(item => item?.code != null)
       array = _uniqBy(array, 'code').sort(sortByCode());
-      // Get the GAP between codes.
-      let index = 0;
-      let isValid;
-      let prevElement;
-      let currentElement;
 
-      const firstElement = array[0];
-      const increase = firstElement.code === '0'.padStart(code_length, '0') ? 0 : 1;
-      do {
-         prevElement = currentElement
-         currentElement = array[index];
-         const code_array = currentElement.code.split('.');
-         const code = code_array[code_array.length - 1] === '' ? code_array[code_array.length - 2] : code_array[code_array.length - 1]
-         isValid = (index + increase) === parseInt(code)
-         index++;
-      } while (isValid && index < array.length);
-
-      const last = isValid ? currentElement : prevElement;
-      const code_array = last ? last.code.split('.') : ['00'];
+      // Get the last code and get the next code
+      const lastCode = array[array.length - 1];
+      const code_array = lastCode.code.split('.');
       code = code_array[code_array.length - 1] === '' ? code_array[code_array.length - 2] : code_array[code_array.length - 1]
       code = parseInt(code);
       code = (code + 1).toString().padStart(code_length, '0')

--- a/src/utils/Utils.js
+++ b/src/utils/Utils.js
@@ -151,9 +151,9 @@ export const chunk = (str, n) => {
 };
 
 /** Generate a new code for a table row from the current codes in the table following these rules
- * It will the next lowest code posible for the last code in the array.
- * Given an array of codes such as ['1','2']. The next lowest posible code will be '3'
- * Given an array of codes such as ['1','3']. The next lowest posible code will be '4'
+ * Returns the next code after the last (highest) code in the array. 
+ * Given an array of codes such as ['1','2']. The next code will be '3'
+ * Given an array of codes such as ['1','3']. The next code will be '4'
  * @param {Array} _array The list of codes that are already in the table
  * @param {Boolean} code_length The length of the new code, EJ. if the code is 1 but length = 2 , the code will be 01
  * @return {String} The generated code

--- a/src/utils/actionQueue.js
+++ b/src/utils/actionQueue.js
@@ -1,0 +1,42 @@
+/**
+ * Creates an in-memory queue that runs actions one at a time per queueKey.
+ *
+ * Used by Toolbar when an action defines `queueKey`. Rapid clicks on the same
+ * button are serialized instead of running in parallel, which prevents race
+ * conditions when each click depends on state updated by the previous one.
+ *
+ * Different queueKey values run independently. A new click executes immediately
+ * when the previous action for that key has already finished.
+ *
+ * @returns {{enqueue: function(string, function): Promise<*>}} Queue controller
+ */
+export const createActionQueue = () => {
+   const queues = {};
+
+   /**
+    * Schedules an action after every prior action with the same queueKey.
+    * @param {string} queueKey Identifier that groups related actions (e.g. parent row id)
+    * @param {Function} action Sync or async function to execute when its turn arrives
+    * @returns {Promise<*>} Result of this specific action
+    */
+   const enqueue = (queueKey, action) => {
+      // First click uses an already-resolved promise, so the action runs immediately.
+      const previousAction = queues[queueKey] || Promise.resolve();
+
+      const currentAction = previousAction
+         // Keep the queue alive when a prior action fails.
+         .catch(() => {})
+         // Run the new action only after the previous one settles.
+         .then(() => Promise.resolve(action()));
+
+      // Store this promise so the next click waits for it.
+      // Swallow errors here so a failed action does not block future clicks.
+      queues[queueKey] = currentAction.catch(() => {});
+
+      return currentAction;
+   };
+
+   return {enqueue};
+};
+
+export default createActionQueue;

--- a/test/actionQueue.test.js
+++ b/test/actionQueue.test.js
@@ -1,0 +1,105 @@
+const { createActionQueue } = require('../src/utils/actionQueue');
+
+describe('createActionQueue', () => {
+  it('should execute an action immediately and return its result', async () => {
+    const { enqueue } = createActionQueue();
+    const parentRowId = 24792;
+    const createChildItem = () => ({
+      id: 1001,
+      parent_id: parentRowId,
+      description: 'REQUERIMIENTOS GENERALES',
+    });
+
+    const result = await enqueue(parentRowId, createChildItem);
+
+    expect(result).toEqual({
+      id: 1001,
+      parent_id: 24792,
+      description: 'REQUERIMIENTOS GENERALES',
+    });
+  });
+
+  it('should serialize actions with the same queueKey', async () => {
+    const { enqueue } = createActionQueue();
+    const parentRowId = 24792;
+    const executionOrder = [];
+    let finishFirstAction;
+    let firstActionStarted;
+
+    const firstActionPending = new Promise((resolve) => {
+      finishFirstAction = resolve;
+    });
+    const firstActionStartedPromise = new Promise((resolve) => {
+      firstActionStarted = resolve;
+    });
+
+    const firstActionPromise = enqueue(parentRowId, async () => {
+      executionOrder.push('create-item-1001');
+      firstActionStarted();
+      await firstActionPending;
+      return { id: 1001, parent_id: parentRowId };
+    });
+
+    const secondActionPromise = enqueue(parentRowId, async () => {
+      executionOrder.push('create-item-1002');
+      return { id: 1002, parent_id: parentRowId };
+    });
+
+    await firstActionStartedPromise;
+    expect(executionOrder).toEqual(['create-item-1001']);
+
+    finishFirstAction();
+
+    const firstResult = await firstActionPromise;
+    const secondResult = await secondActionPromise;
+
+    expect(firstResult).toEqual({ id: 1001, parent_id: 24792 });
+    expect(secondResult).toEqual({ id: 1002, parent_id: 24792 });
+    expect(executionOrder).toEqual(['create-item-1001', 'create-item-1002']);
+  });
+
+  it('should run actions with different queueKeys in parallel', async () => {
+    const { enqueue } = createActionQueue();
+    const parentRowA = 24792;
+    const parentRowB = 24793;
+    const executionOrder = [];
+    let finishActionA;
+    let actionAStarted;
+
+    const actionAPending = new Promise((resolve) => {
+      finishActionA = resolve;
+    });
+    const actionAStartedPromise = new Promise((resolve) => {
+      actionAStarted = resolve;
+    });
+
+    const actionAPromise = enqueue(parentRowA, async () => {
+      executionOrder.push('parent-24792-started');
+      actionAStarted();
+      await actionAPending;
+      executionOrder.push('parent-24792-finished');
+      return { id: 1001, parent_id: parentRowA };
+    });
+
+    const actionBPromise = enqueue(parentRowB, async () => {
+      executionOrder.push('parent-24793-finished');
+      return { id: 1002, parent_id: parentRowB };
+    });
+
+    await actionAStartedPromise;
+
+    const resultB = await actionBPromise;
+    expect(resultB).toEqual({ id: 1002, parent_id: 24793 });
+    expect(executionOrder).toEqual(['parent-24792-started', 'parent-24793-finished']);
+
+    finishActionA();
+
+    const resultA = await actionAPromise;
+    expect(resultA).toEqual({ id: 1001, parent_id: 24792 });
+    expect(executionOrder).toEqual([
+      'parent-24792-started',
+      'parent-24793-finished',
+      'parent-24792-finished',
+    ]);
+  });
+});

--- a/test/utils/Utils.test.js
+++ b/test/utils/Utils.test.js
@@ -1,0 +1,73 @@
+const { generateCode } = require('../../src/utils/Utils');
+
+describe('generateCode', () => {
+  it('should return 01 when the array is empty', () => {
+    expect(generateCode([])).toBe('01');
+  });
+
+  it('should return the next code after the last existing code', () => {
+    const items = [
+      { code: '01' },
+      { code: '02' },
+    ];
+
+    expect(generateCode(items)).toBe('03');
+  });
+
+  it('should use the highest code when there is a gap', () => {
+    const items = [
+      { code: '01' },
+      { code: '03' },
+    ];
+
+    expect(generateCode(items)).toBe('04');
+  });
+
+  it('should use the last segment of hierarchical codes', () => {
+    const items = [
+      { code: '01.01' },
+      { code: '01.02' },
+    ];
+
+    expect(generateCode(items)).toBe('03');
+  });
+
+  it('should handle trailing dots in codes', () => {
+    const items = [
+      { code: '01.' },
+      { code: '02.' },
+    ];
+
+    expect(generateCode(items)).toBe('03');
+  });
+
+  it('should ignore items without a code', () => {
+    const items = [
+      { code: '01' },
+      { code: null },
+      {},
+      { code: '02' },
+    ];
+
+    expect(generateCode(items)).toBe('03');
+  });
+
+  it('should pad the result to the given code_length', () => {
+    const items = [
+      { code: '001' },
+      { code: '002' },
+    ];
+
+    expect(generateCode(items, 3)).toBe('003');
+  });
+
+  it('should sort codes before picking the last one', () => {
+    const items = [
+      { code: '03' },
+      { code: '01' },
+      { code: '02' },
+    ];
+
+    expect(generateCode(items)).toBe('04');
+  });
+});

--- a/test/utils/actionQueue.test.js
+++ b/test/utils/actionQueue.test.js
@@ -1,4 +1,4 @@
-const { createActionQueue } = require('../src/utils/actionQueue');
+const { createActionQueue } = require('../../src/utils/actionQueue');
 
 describe('createActionQueue', () => {
   it('should execute an action immediately and return its result', async () => {

--- a/test/utils/index.test.js
+++ b/test/utils/index.test.js
@@ -1,4 +1,4 @@
-const { applyFilter, fixRowsFromClipboard } = require('../src/utils/index');
+const { applyFilter, fixRowsFromClipboard } = require('../../src/utils/index');
 
 describe('applyFilter', () => {
   it('should apply status filters correctly', () => {


### PR DESCRIPTION
## Notion Task
- [2754 — Revisar condición de carrera al agregar muy rápido conceptos en tabla](https://app.notion.com/p/Revisar-condici-n-de-carrera-al-agregar-muy-rapido-conceptos-en-tabla-39ef16d935b580598750ea75d6f5a6ec?source=copy_link)

## Summary
- Add an in-memory action queue so toolbar actions with the same `queueKey` run one at a time
- Prevents race conditions when users click add/create actions very quickly on the same parent row
- Extend `custom_button` to receive `onClick`, `loading`, and `disabled` so queued handlers work with custom UI
- Include unit tests for immediate execution, same-key serialization, and parallel different keys

## Changes by Category
### [NEW]
- `createActionQueue` utility and optional `queueKey` on toolbar actions

### [UPDATE]
- Toolbar routes actions through the queue when `queueKey` is set
- `custom_button` receives `onClick`, `loading`, and `disabled`

## Version
Version bumped from 1.18.23 to 1.18.24

## Test Plan
- [ ] Unit tests pass (`yarn test test/actionQueue.test.js`)
- [ ] Manual: rapid-click an add action with `queueKey` and confirm items are created sequentially without races
- [ ] Manual: actions without `queueKey` still fire immediately as before
- [ ] Manual: `custom_button` actions still work and honor the passed `onClick` when queuing is needed
- [ ] No breaking changes for consumers that ignore the new `custom_button` argument


Made with [Cursor](https://cursor.com)