### PR TITLE
[Hotfix] Remove duplicated object keys and guard frozen column width math

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # FIVEBIM-TABLE.
 This file is used to explain in detail changes made to the Table.
 
+## V 1.18.26
+Date: Jul 29, 2026
+* [FIX]
+  * Remove duplicated `width` key in the `TableDatePicker` inline style and duplicated `item` key in the row `useDrag` spec, keeping the effective values in both cases
+  * Coerce frozen column widths with `Number(...) || 0` in `getFrozenStickyStyles` so a non-numeric or missing `width` no longer produces a `NaN` sticky offset
+
 ## V 1.18.25
 Date: Jul 22, 2026
 * [FIX]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermosillo-i3/table-pkg",
-  "version": "1.18.25",
+  "version": "1.18.26",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/InputField.js
+++ b/src/components/InputField.js
@@ -908,7 +908,6 @@ class InputField extends React.Component {
             <TableDatePicker
               selected={selected}
               style={{
-                width: '100%',
                 border: shouldShowBorder ? '2px solid #1f76b7' : '2px solid transparent',
                 width: this.props.allowNewRowSelectionProcess ? customWidth : '100%',
                 minWidth: '70%',

--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -141,10 +141,6 @@ const rowFunctionComponent = (props) => {
    // Definimos los hooks useDrag y useDrop
    const [{ isDragging, canDrag }, connectDragSource] = useDrag({
       type: ItemTypes.ROW,
-      item: {
-         row: row,
-         type: props.type,
-      },
       canDrag: (monitor) => {
          return props.canDrag ? props.canDrag(props, monitor) : false;
       },

--- a/src/utils/table-utils.js
+++ b/src/utils/table-utils.js
@@ -13,7 +13,7 @@ export function getFrozenStickyStyles(columns, colIndex, isDragColumnVisible) {
    }
    for (let j = 0; j < colIndex; j++) {
       if (columns[j]?.freeze) {
-         left += columns[j].width;
+         left += Number(columns[j].width) || 0;
       }
    }
    return {


### PR DESCRIPTION
## Summary
- Removes two duplicated object keys where the second definition silently overrode the first, so the intent of the code is now explicit.
- Hardens the frozen-column offset calculation so a non-numeric or missing `width` cannot produce a `NaN` `left` value on sticky cells.
- No behavior change is expected from the duplicate-key removals: in both cases the surviving value is the one that was already winning at runtime.

## Changes by Category
### [FIX]
- `src/components/InputField.js`: drop the first `width: '100%'` in the `TableDatePicker` inline style; the effective `width: allowNewRowSelectionProcess ? customWidth : '100%'` stays.
- `src/components/Row.js`: drop the static `item: {row, type}` from the `useDrag` spec; the later `item: () => ({row, type})` function form stays, so the drag payload is unchanged.
- `src/utils/table-utils.js`: in `getFrozenStickyStyles`, accumulate `Number(columns[j].width) || 0` instead of `columns[j].width`, so a string or undefined width no longer poisons the sticky `left` offset.

## Version
Version bumped from 1.18.25 to 1.18.26

## Test Plan
- [x] `yarn test` passes (21 tests, 2 suites)
- [ ] Date picker cells render at the expected width, both with and without `allowNewRowSelectionProcess`
- [ ] Row drag and drop still works (drop handler receives `{row, type}`)
- [ ] Frozen/`freeze` columns stay aligned while scrolling horizontally, including when a column width is defined as a string
- [ ] No breaking changes

## Review notes (optional follow-ups)
- `getFrozenStickyStyles` has no unit test even though this PR changes its arithmetic; a small test asserting a numeric `left` when a frozen column has a string or missing `width` would lock in the fix.
- The `table-utils.js` change is a defensive numeric guard rather than a duplicate-key removal, so it is slightly broader than the branch name suggests.
- After this version is published, `fivebim-app` still pins `@hermosillo-i3/table-pkg` at `1.18.25` and will need a separate bump to pick it up.

Made with [Cursor](https://cursor.com)