### PR TITLE
[Hotfix] Add onSortChange for server-side column sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # FIVEBIM-TABLE.
 This file is used to explain in detail changes made to the Table.
 
+## V 1.18.27
+Date: Aug 4, 2026
+* [NEW]
+  * Add optional `onSortChange` prop so column header clicks can request server-side sorting; while active, row order is preserved via each row's `order_position`
+
 ## V 1.18.26
 Date: Jul 29, 2026
 * [FIX]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermosillo-i3/table-pkg",
-  "version": "1.18.26",
+  "version": "1.18.27",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -1652,6 +1652,10 @@ class Table extends React.Component {
                         className={is_sortable ? `${col.Header !== '' && col.columns ? 'Table-Column-Header-Groups-Sortable' : 'Table-Column-Header-Sortable'}` : null}
                         style={{ textAlign: 'center' }}
                         onClick={is_sortable ? () => {
+                           const previousDirection = this.state.column_extended[col.assesor]?.sort_directon;
+                           const nextDirection = previousDirection === 'up' ? 'down' : 'up';
+                           const usesServerSort = typeof this.props.onSortChange === 'function';
+
                            this.setState((prevState) => ({
                               column_extended: Object.keys(prevState.column_extended).reduce((acum, key) => {
                                  if (key === col.assesor) {
@@ -1659,7 +1663,7 @@ class Table extends React.Component {
                                        ...acum,
                                        [col.assesor]: {
                                           ...prevState.column_extended[col.assesor],
-                                          sort_directon: prevState.column_extended[col.assesor].sort_directon === 'up' ? 'down' : 'up'
+                                          sort_directon: nextDirection,
                                        }
                                     }
                                  }
@@ -1672,8 +1676,11 @@ class Table extends React.Component {
 
                                  }
                               }, {}),
-                              sortMethod: col.sortMethod ? col.sortMethod : (a, b) => {
-                                 let sortUp = prevState.column_extended[col.assesor].sort_directon === 'up'
+                              // Server-side sort: keep API order via each row's `order_position`
+                              sortMethod: usesServerSort
+                                 ? (a, b) => (a.order_position ?? 0) - (b.order_position ?? 0)
+                                 : (col.sortMethod ? col.sortMethod : (a, b) => {
+                                 let sortUp = previousDirection === 'up'
                                  let clean = str => {
                                     let tmp = replaceAll(str, '\\/', '')
                                     tmp = replaceAll(tmp, '\\.', '')
@@ -1686,8 +1693,15 @@ class Table extends React.Component {
                                  } else {
                                     return clean(a[col.assesor]) > clean(b[col.assesor]) ? (sortUp ? 1 : -1) : (sortUp ? -1 : 1)
                                  }
-                              }
-                           }))
+                              }),
+                           }));
+
+                           if (usesServerSort) {
+                              this.props.onSortChange({
+                                 field: col.assesor,
+                                 direction: nextDirection === 'up' ? 'ASC' : 'DESC',
+                              });
+                           }
                         } : undefined}
                      >
                         {typeof col.Header === 'string' ? col.Header : col.Header()}
@@ -2053,6 +2067,15 @@ Table.propTypes = {
    orderByCode: PropTypes.bool,
    orderByAlphanumericCode: PropTypes.bool,
    sort: PropTypes.func,
+   /**
+    * When provided, column header clicks request server-side sorting instead of
+    * reordering the rows already loaded in the table. While that request is in
+    * flight (and after it returns), the table preserves the loaded page order via
+    * each row's numeric `order_position` field — consumers must set
+    * `order_position` on every row (typically the index in the server page order).
+    * @param {{field: string, direction: 'ASC'|'DESC'}} sort
+    */
+   onSortChange: PropTypes.func,
    expandCollapseColumnIndex: PropTypes.number,
    isDragColumnVisible: PropTypes.bool,
 


### PR DESCRIPTION
## Notion Task
- [2818 — Aplicar logica de paginado en reportes de seguridad globales](https://app.notion.com/p/Aplicar-logica-de-paginado-en-reportes-de-seguridad-globales-3a5f16d935b580b992d6ed506f242c0d?v=2e6f16d935b580099975000c49808f6b&source=copy_link)

## Summary
- Add optional `onSortChange` so header clicks can request server-side sorting instead of reordering only the loaded rows
- While server sort is active, preserve API order via each row's `order_position`

## Changes by Category
### [NEW]
- `onSortChange` prop on `Table` for server-side column sorting
- Document that consumers must set `order_position` on rows when using `onSortChange`

## Version
Version bumped from 1.18.26 to 1.18.27

## Test Plan
- [ ] With `onSortChange`, clicking a sortable header calls the callback with `{ field, direction }` and does not locally reorder by cell values
- [ ] Without `onSortChange`, existing client-side column sort still works
- [ ] Rows with `order_position` keep server order after a header click when `onSortChange` is set
