### PR TITLE
[Hotfix] Keep Decimal values in CSV export (filterRowValues)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # FIVEBIM-TABLE.
 This file is used to explain in detail changes made to the Table.
 
+## V 1.18.28
+Date: Aug 12, 2026
+* [FIX]
+  * Keep Decimal (and null) values when exporting CSV via `filterRowValues`, so currency/quantity columns are no longer dropped
+
 ## V 1.18.27
 Date: Aug 4, 2026
 * [NEW]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermosillo-i3/table-pkg",
-  "version": "1.18.27",
+  "version": "1.18.28",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/utils/Utils.js
+++ b/src/utils/Utils.js
@@ -1,4 +1,5 @@
 import dateFormatter from "@hermosillo-i3/utils-pkg/src/dateFormatter";
+import {Decimal} from "decimal.js";
 import { sortByCode } from "./index";
 import _uniqBy from "lodash/uniqBy";
 
@@ -483,9 +484,28 @@ export const getAllParents = (item, list_of_items) => {
 
 
 /**
+ * Serializes a value so CSV export keeps primitives and Decimal numbers.
+ * Plain objects, functions and symbols are omitted by the caller.
+ * @param {*} value - Cell value from a table row
+ * @returns {*|null|undefined} Primitive/null to keep, or undefined to drop the key
+ */
+const serializeCsvCellValue = (value) => {
+   if (value == null) {
+      return value;
+   }
+   if (typeof value !== 'object') {
+      return value;
+   }
+   if (Decimal.isDecimal(value)) {
+      return value.toString();
+   }
+   return undefined;
+};
+
+/**
  * Filter object values by its types
  * @param {Object} row Row's object 
- * @returns {Object} Object without function and object values
+ * @returns {Object} Object without function and plain object values (Decimal is kept as string)
  */
 export const filterRowValues = (row) => {
    return Object.entries(row).reduce((accum, [key, value]) => {
@@ -497,13 +517,27 @@ export const filterRowValues = (row) => {
       }
       switch (typeof value) {
          case 'object':
+            if (value == null) {
+               return {
+                  ...accum,
+                  [key]: value,
+               }
+            }
             if (Array.isArray(value)) {
                return {
                   ...accum,
                   [key]: filterArrayObjectValuesRecursively(value).filter((n) => n != null && n != undefined),
                }
-            } else {
-               return accum;
+            }
+            {
+               const serializedValue = serializeCsvCellValue(value);
+               if (serializedValue === undefined) {
+                  return accum;
+               }
+               return {
+                  ...accum,
+                  [key]: serializedValue,
+               }
             }
          case 'function':
             return accum;
@@ -527,10 +561,15 @@ const filterArrayObjectValuesRecursively = (arr) => {
    return arr.map((value) => {
       switch (typeof value) {
          case 'object':
+            if (value == null) {
+               return value;
+            }
             if (Array.isArray(value)) {
                return filterArrayObjectValuesRecursively(value).filter((n) => n != null && n != undefined);
-            } else {
-               return null;
+            }
+            {
+               const serializedValue = serializeCsvCellValue(value);
+               return serializedValue === undefined ? null : serializedValue;
             }
          case 'function':
             return null;


### PR DESCRIPTION
## Notion Task
- [3011 — Bug: Excel de “Importe real en pedido” aparece incompleto](https://app.notion.com/p/3baf16d935b58017aaa3cb9a58ff74ac)

## Summary
- CSV export via `allowToDownloadCVS` dropped Decimal cell values because `filterRowValues` discarded non-array objects
- Serialize Decimal (and keep null) so currency/quantity columns appear in the exported CSV

## Changes by Category
### [FIX]
- Keep Decimal (and null) values when exporting CSV via `filterRowValues`

## Version
Version bumped from 1.18.27 to 1.18.28

## Test Plan
- [ ] yarn link table-pkg into fivebim-app (or consume 1.18.28)
- [ ] Open Importe real en pedido and download CSV
- [ ] Confirm Disponible, Total, Facturado, and Comprometido are present
- [ ] No breaking changes for other CSV exports